### PR TITLE
Issue #81: Notice: Undefined index: label in RulesUICategory::getOptions()

### DIFF
--- a/modules/rules_core.rules.inc
+++ b/modules/rules_core.rules.inc
@@ -145,6 +145,7 @@ function rules_rules_core_data_info() {
   }
 
   if (module_exists('taxonomy')) {
+    $return['taxonomy_vocabulary']['label'] = t('Taxonomy Vocabulary');
     // For exportability identify vocabularies by name.
     $return['taxonomy_vocabulary']['wrapper class'] = 'RulesTaxonomyVocabularyWrapper';
     $return['taxonomy_vocabulary']['ui class'] = 'RulesDataUITaxonomyVocabulary';


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/rules/issues/81.

Add a label to the rules data for the ‘taxonomy_vocabulary’ type, which fixes a watchdog warning.