### PR TITLE
Add mention of Wiki to README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ and enter the required information.
 
 ## Documentation
 
-Additional documentation is located in [the Wiki](https://github.com/backdrop-contrib/rules/wiki/Documentation).
+Additional documentation is located in [the Wiki](https://github.com/backdrop-contrib/rules/wiki).
 
 ## Debug Information
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Then visit the configuration page at Administration >
 Configuration > Category > Rules (admin/config/category/rules)
 and enter the required information.
 
+## Documentation
+
+Additional documentation is located in [the Wiki](https://github.com/backdrop-contrib/rules/wiki/Documentation).
+
 ## Debug Information
 
 An administrative setting enables debug information to be shown when 


### PR DESCRIPTION
Per [this recent Zulip discussion](https://backdrop.zulipchat.com/#narrow/stream/218635-Backdrop/topic/User.20Guide.3A.20Contributed.20Modules) about contrib documentation, I've removed the Rules pages from the User Guide and created Wiki pages for each here.

Then, per the recommended README.md guidelines, I'm adding a reference to the Wiki so that users will be able to find the Wiki pages from the Backdrop project page.