### PR TITLE
Issue 95: Ubercart-Rules watchdog messages are all errors

### DIFF
--- a/rules.install
+++ b/rules.install
@@ -207,16 +207,16 @@ function rules_update_1001() {
 function rules_update_1000() {
   // Migrate variables to config.
   $config = config('rules.settings');
-  $config->set('rules_log_errors', update_variable_get('rules_log_errors', 'RulesLog::WARN'));
-  $config->set('rules_log_level', update_variable_get('rules_log_level', 'self::INFO'));
-  $config->set('rules_debug_log', update_variable_get('rules_debug_log', '0'));
-  $config->set('rules_debug', update_variable_get('rules_log_debug', 'RulesLog::WARN'));
-  $config->set('language_content_type_page', update_variable_get('language_content_type_page', '1'));
+  $config->set('rules_log_errors', update_variable_get('rules_log_errors', RulesLog::WARN));
+  $config->set('rules_log_level', update_variable_get('rules_log_level', RulesLog::INFO));
+  $config->set('rules_debug_log', update_variable_get('rules_debug_log', 0));
+  $config->set('rules_debug', update_variable_get('rules_log_debug', RulesLog::WARN));
+  $config->set('language_content_type_page', update_variable_get('language_content_type_page', 1));
   $config->set('rules_path_cleaning_callback', update_variable_get('rules_path_cleaning_callback', 'rules_path_default_cleaning_method'));
   $config->set('rules_path_replacement_char', update_variable_get('rules_path_replacement_char', '-'));
-  $config->set('rules_path_lower_case', update_variable_get('rules_path_lower_case', 'TRUE'));
+  $config->set('rules_path_lower_case', update_variable_get('rules_path_lower_case', TRUE));
   $config->set('rules_clean_path', update_variable_get('rules_clean_path', 'array("/[^a-zA-Z0-9\-_]+/", $replace)'));
-  $config->set('rules_path_transliteration', update_variable_get('rules_path_transliteration', 'TRUE'));
+  $config->set('rules_path_transliteration', update_variable_get('rules_path_transliteration', TRUE));
   $config->save();
 
   // Delete variables.

--- a/rules.install
+++ b/rules.install
@@ -215,7 +215,7 @@ function rules_update_1000() {
   $config->set('rules_path_cleaning_callback', update_variable_get('rules_path_cleaning_callback', 'rules_path_default_cleaning_method'));
   $config->set('rules_path_replacement_char', update_variable_get('rules_path_replacement_char', '-'));
   $config->set('rules_path_lower_case', update_variable_get('rules_path_lower_case', TRUE));
-  $config->set('rules_clean_path', update_variable_get('rules_clean_path', array("/[^a-zA-Z0-9\-_]+/", $replace)));
+  $config->set('rules_clean_path', update_variable_get('rules_clean_path', array("/[^a-zA-Z0-9\-_]+/", "")));
   $config->set('rules_path_transliteration', update_variable_get('rules_path_transliteration', TRUE));
   $config->save();
 

--- a/rules.install
+++ b/rules.install
@@ -215,7 +215,7 @@ function rules_update_1000() {
   $config->set('rules_path_cleaning_callback', update_variable_get('rules_path_cleaning_callback', 'rules_path_default_cleaning_method'));
   $config->set('rules_path_replacement_char', update_variable_get('rules_path_replacement_char', '-'));
   $config->set('rules_path_lower_case', update_variable_get('rules_path_lower_case', TRUE));
-  $config->set('rules_clean_path', update_variable_get('rules_clean_path', array("/[^a-zA-Z0-9\-_]+/", "")));
+  $config->set('rules_clean_path', update_variable_get('rules_clean_path', array('/[^a-zA-Z0-9\-_]+/', '-')));
   $config->set('rules_path_transliteration', update_variable_get('rules_path_transliteration', TRUE));
   $config->save();
 

--- a/rules.install
+++ b/rules.install
@@ -215,7 +215,7 @@ function rules_update_1000() {
   $config->set('rules_path_cleaning_callback', update_variable_get('rules_path_cleaning_callback', 'rules_path_default_cleaning_method'));
   $config->set('rules_path_replacement_char', update_variable_get('rules_path_replacement_char', '-'));
   $config->set('rules_path_lower_case', update_variable_get('rules_path_lower_case', TRUE));
-  $config->set('rules_clean_path', update_variable_get('rules_clean_path', 'array("/[^a-zA-Z0-9\-_]+/", $replace)'));
+  $config->set('rules_clean_path', update_variable_get('rules_clean_path', array("/[^a-zA-Z0-9\-_]+/", $replace)));
   $config->set('rules_path_transliteration', update_variable_get('rules_path_transliteration', TRUE));
   $config->save();
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/rules/issues/95.

I've run an upgrade with this change on a site that formerly exhibited the problem after upgrade and it now upgrades with no more of these watchdog error messages.