### PR TITLE
Issue 89: Rename rules_config_delete().

### DIFF
--- a/rules.module
+++ b/rules.module
@@ -974,7 +974,7 @@ function rules_get_components($label = FALSE, $type = NULL, $conditions = array(
  * @param array $ids
  *   An array of entity IDs.
  */
-function rules_config_delete(array $ids) {
+function rules_configuration_delete(array $ids) {
   return entity_get_controller('rules_config')->delete($ids);
 }
 


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/rules/issues/89.