### PR TITLE
Issue 113: Rules sub-module tests missing *.tests.info files

### DIFF
--- a/rules_admin/tests/rules_admin.test
+++ b/rules_admin/tests/rules_admin.test
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Rules UI tests.
@@ -9,17 +8,6 @@
  * Tests for creating rules through the UI.
  */
 class RulesUiTestCase extends BackdropWebTestCase {
-
-  /**
-   * Declares test metadata.
-   */
-  public static function getInfo() {
-    return array(
-      'name' => 'Rules UI Tests ',
-      'description' => 'Tests Rules UI.',
-      'group' => 'Rules',
-    );
-  }
 
   /**
    * Overrides BackdropWebTestCase::setUp().

--- a/rules_admin/tests/rules_admin.tests.info
+++ b/rules_admin/tests/rules_admin.tests.info
@@ -1,0 +1,11 @@
+[RulesUiTestCase]
+name = Rules UI Tests
+description = Tests Rules UI.
+group = Rules
+file = rules_admin.test
+
+[RulesAdminMinimalProfileTestCase]
+name = Rules UI Minimal Profile Tests
+description = Tests UI support for minimal profile.
+group = Rules
+file = rules_admin_minimal_profile.test

--- a/rules_admin/tests/rules_admin_minimal_profile.test
+++ b/rules_admin/tests/rules_admin_minimal_profile.test
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Rules UI tests.
@@ -20,17 +19,6 @@ class RulesAdminMinimalProfileTestCase extends BackdropWebTestCase {
    * {@inheritdoc}
    */
   protected $profile = 'minimal';
-
-  /**
-   * Declares test metadata.
-   */
-  public static function getInfo() {
-    return array(
-      'name' => 'Rules UI Minimal Profile Tests ',
-      'description' => 'Tests UI support for minimal profile.',
-      'group' => 'Rules',
-    );
-  }
 
   /**
    * Overrides BackdropWebTestCase::setUp().

--- a/rules_i18n/tests/rules_i18n.test
+++ b/rules_i18n/tests/rules_i18n.test
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Rules i18n tests.
@@ -9,18 +8,6 @@
  * Test the i18n integration.
  */
 class RulesI18nTestCase extends BackdropWebTestCase {
-
-  /**
-   * Declares test metadata.
-   */
-  public static function getInfo() {
-    return array(
-      'name' => 'Rules I18n',
-      'description' => 'Tests translating Rules configs.',
-      'group' => 'Rules',
-      'dependencies' => array('i18n_string'),
-    );
-  }
 
   /**
    * Overrides BackdropWebTestCase::setUp().

--- a/rules_i18n/tests/rules_i18n.tests.info
+++ b/rules_i18n/tests/rules_i18n.tests.info
@@ -1,0 +1,6 @@
+[RulesI18nTestCase]
+name = Rules I18n
+description = Tests translating Rules configs.
+group = Rules
+file = rules_scheduler.test
+dependencies[] = i18n_string

--- a/rules_scheduler/tests/rules_scheduler.test
+++ b/rules_scheduler/tests/rules_scheduler.test
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * Rules Scheduler tests.
@@ -9,17 +8,6 @@
  * Test cases for the Rules Scheduler module.
  */
 class RulesSchedulerTestCase extends BackdropWebTestCase {
-
-  /**
-   * Declares test metadata.
-   */
-  public static function getInfo() {
-    return array(
-      'name' => 'Rules Scheduler tests',
-      'description' => 'Test scheduling components.',
-      'group' => 'Rules',
-    );
-  }
 
   /**
    * Overrides BackdropWebTestCase::setUp().

--- a/rules_scheduler/tests/rules_scheduler.tests.info
+++ b/rules_scheduler/tests/rules_scheduler.tests.info
@@ -1,0 +1,5 @@
+[RulesSchedulerTestCase]
+name = Rules Scheduler tests
+description = Test scheduling components.
+group = Rules
+file = rules_scheduler.test


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/rules/issues/113.