### PR TITLE
Issue #149: isolate test files from normal-operation module files.

### DIFF
--- a/includes/rules.core.inc
+++ b/includes/rules.core.inc
@@ -1805,14 +1805,6 @@ abstract class RulesAbstractPlugin extends RulesPlugin {
       foreach ($this->faces as $interface) {
         $methods = $file_names = array();
         $includes = self::getIncludeFiles($info['module']);
-
-        // Make sure we've actually included all of the include files so that
-        // the call to getFileName() in the next section will succeed if the
-        // function lives in a file included via hook_rules_file_info().
-        foreach ($includes as $file) {
-          module_load_include('inc', $info['module'], $file);
-        }
-
         foreach (get_class_methods($interface) as $method) {
           if (isset($info['callbacks'][$method]) && ($function = $info['callbacks'][$method])) {
             $methods[$method][0] = $function;
@@ -1845,7 +1837,7 @@ abstract class RulesAbstractPlugin extends RulesPlugin {
    * callbacks may reside in that file.
    */
   protected function loadBasicInclude() {
-    static $included = array();
+    $included = &backdrop_static(__METHOD__, array());
 
     if (isset($this->info['module']) && !isset($included[$this->info['module']])) {
       $module = $this->info['module'];
@@ -1858,7 +1850,7 @@ abstract class RulesAbstractPlugin extends RulesPlugin {
    * Makes sure all supported destinations are included.
    */
   public static function includeFiles() {
-    static $included;
+    $included = &backdrop_static(__METHOD__);
 
     if (!isset($included)) {
       foreach (module_implements('rules_file_info') as $module) {
@@ -1910,7 +1902,7 @@ abstract class RulesAbstractPlugin extends RulesPlugin {
   }
 
   protected function getFileName($function, $includes) {
-    static $filenames;
+    $filenames = &backdrop_static(__METHOD__);
     if (!isset($filenames) || !array_key_exists($function, $filenames)) {
       $filenames[$function] = NULL;
       $reflector = new ReflectionFunction($function);

--- a/includes/rules.core.inc
+++ b/includes/rules.core.inc
@@ -1806,6 +1806,13 @@ abstract class RulesAbstractPlugin extends RulesPlugin {
         $methods = $file_names = array();
         $includes = self::getIncludeFiles($info['module']);
 
+        // Make sure we've actually included all of the include files so that
+        // the call to getFileName() in the next section will succeed if the
+        // function lives in a file included via hook_rules_file_info().
+        foreach ($includes as $file) {
+          module_load_include('inc', $info['module'], $file);
+        }
+
         foreach (get_class_methods($interface) as $method) {
           if (isset($info['callbacks'][$method]) && ($function = $info['callbacks'][$method])) {
             $methods[$method][0] = $function;
@@ -1905,7 +1912,6 @@ abstract class RulesAbstractPlugin extends RulesPlugin {
   protected function getFileName($function, $includes) {
     static $filenames;
     if (!isset($filenames) || !array_key_exists($function, $filenames)) {
-      module_load_include('inc','rules','tests/rules_test.test');
       $filenames[$function] = NULL;
       $reflector = new ReflectionFunction($function);
       // On windows the path contains backslashes instead of slashes, fix that.

--- a/rules.module
+++ b/rules.module
@@ -516,9 +516,17 @@ function rules_flush_caches() {
  */
 function rules_clear_cache() {
   cache_clear_all('*', 'cache_rules', TRUE);
+
   backdrop_static_reset('rules_get_cache');
   backdrop_static_reset('rules_fetch_data');
   backdrop_static_reset('rules_config_update_dirty_flag');
+
+  backdrop_static_reset('RulesAbstractPlugin::loadBasicInclude');
+  backdrop_static_reset('RulesAbstractPlugin::includeFiles');
+  backdrop_static_reset('RulesAbstractPlugin::getFileName');
+
+  backdrop_static_reset('_rules_import_get_plugin');
+
   entity_get_controller('rules_config')->resetCache();
 }
 

--- a/rules_scheduler/rules_scheduler.module
+++ b/rules_scheduler/rules_scheduler.module
@@ -219,6 +219,7 @@ function rules_scheduler_views_api() {
     'path' => backdrop_get_path('module', 'rules_scheduler') .'/includes',
   );
 }
+
 /**
  * Implements hook_autoload_info().
  */
@@ -228,7 +229,5 @@ function rules_scheduler_autoload_info()
     'RulesSchedulerSchedulerTestCase' => 'rules_scheduler.test',
     'RulesSchedulerDefaultTaskHandler' => 'includes/rules_scheduler.handler.inc',
     'rules_scheduler_views_filter' => 'includes/rules_scheduler_views_filter.inc',
-    'RulesTestTaskHandler' => 'tests/rules_scheduler_test.inc',
   );
 }
-

--- a/rules_scheduler/tests/rules_scheduler_test/rules_scheduler_test.module
+++ b/rules_scheduler/tests/rules_scheduler_test/rules_scheduler_test.module
@@ -3,3 +3,13 @@
  * @file
  * Rules Scheduler test module.
  */
+
+/**
+ * Implements hook_autoload_info().
+ */
+function rules_scheduler_test_autoload_info()
+{
+  return array(
+    'RulesTestTaskHandler' => 'rules_scheduler_test.inc',
+  );
+}

--- a/tests/rules.test
+++ b/tests/rules.test
@@ -2110,7 +2110,7 @@ class RulesIntegrationTestCase extends BackdropWebTestCase {
     foreach ($additional_roles as $index => $role) {
       if ($role == BACKDROP_AUTHENTICATED_ROLE) {
         unset($additional_roles[$index]);
-      } 
+      }
     }
 
     // Execute action and check that only two mails were sent.

--- a/tests/rules.test
+++ b/tests/rules.test
@@ -13,7 +13,7 @@ class RulesTestCase extends BackdropWebTestCase {
    * Overrides BackdropWebTestCase::setUp().
    */
   protected function setUp() {
-    parent::setUp('entity_plus', 'locale', 'rules', 'rules_test');
+    parent::setUp('entity_plus', 'rules', 'rules_test');
     RulesLog::logger()->clear();
     config_set('rules.settings', 'rules_debug_log', 1);
   }
@@ -981,7 +981,7 @@ class RulesTestDataCase extends BackdropWebTestCase {
    * Overrides BackdropWebTestCase::setUp().
    */
   protected function setUp() {
-    parent::setUp('entity_plus', 'locale', 'rules', 'rules_test');
+    parent::setUp('entity_plus', 'rules', 'rules_test');
     config_set('rules.settings','rules_debug_log', 1);
     // Make sure we don't ran over issues with the node_load static cache.
     entity_get_controller('node')->resetCache();
@@ -1130,7 +1130,7 @@ class RulesTriggerTestCase extends BackdropWebTestCase {
    * Overrides BackdropWebTestCase::setUp().
    */
   protected function setUp() {
-    parent::setUp('entity_plus', 'locale', 'rules', 'rules_test');
+    parent::setUp('entity_plus', 'rules', 'rules_test');
     RulesLog::logger()->clear();
     config_set('rules.settings','rules_debug_log', 1);
   }
@@ -1389,7 +1389,7 @@ class RulesIntegrationTestCase extends BackdropWebTestCase {
    * Overrides BackdropWebTestCase::setUp().
    */
   protected function setUp() {
-    $setup_modules = array('entity_plus', 'locale', 'rules', 'rules_test', 'path', 'entity_token');
+    $setup_modules = array('entity_plus', 'rules', 'rules_test', 'path', 'entity_token');
     $available_modules = system_rebuild_module_data();
     if (isset($available_modules['php'])) {
       $this->has_php = TRUE;
@@ -2185,7 +2185,7 @@ class RulesEventDispatcherTestCase extends BackdropWebTestCase {
    * Overrides BackdropWebTestCase::setUp().
    */
   protected function setUp() {
-    parent::setUp('entity_plus', 'locale', 'rules', 'rules_test');
+    parent::setUp('entity_plus', 'rules', 'rules_test');
   }
 
   /**
@@ -2248,7 +2248,7 @@ class RulesInvocationEnabledTestCase extends BackdropWebTestCase {
    * Overrides BackdropWebTestCase::setUp().
    */
   protected function setUp() {
-    parent::setUp('entity_plus', 'locale', 'dblog', 'rules', 'rules_test', 'rules_test_invocation');
+    parent::setUp('entity_plus', 'dblog', 'rules', 'rules_test', 'rules_test_invocation');
   }
 
   /**

--- a/tests/rules_test/rules_test.install
+++ b/tests/rules_test/rules_test.install
@@ -8,7 +8,9 @@
  * Implements hook_enable().
  */
 function rules_test_enable() {
-  // Reset the static variable record of what Rules files have been included so
-  // that the list will be rebuilt to include our test files.
-  backdrop_static_reset('RulesAbstractPlugin::includeFiles');
+  // Clear the rules cache so that lists of included files (among other things)
+  // that are cached will be rebuilt so that we can immediately make use of
+  // rules defined in this module that might be triggered by the enabling of
+  // this module.
+  rules_clear_cache();
 }

--- a/tests/rules_test/rules_test.install
+++ b/tests/rules_test/rules_test.install
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @file
+ * Installation functions for the Rules test module.
+ */
+
+/**
+ * Implements hook_enable().
+ */
+function rules_test_enable() {
+  // Reset the static variable record of what Rules files have been included so
+  // that the list will be rebuilt to include our test files.
+  backdrop_static_reset('RulesAbstractPlugin::includeFiles');
+}

--- a/tests/rules_test/rules_test.module
+++ b/tests/rules_test/rules_test.module
@@ -4,8 +4,6 @@
  * Rules test module.
  */
 
- module_load_include('inc', 'rules_test', 'rules_test.rules');
-
 /**
  * Implements hook_entity_property_info_alter() to add a property without
  * access.


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/rules/issues/149.
Fixes https://github.com/backdrop-contrib/rules/issues/142 also.

This PR fixes a regression introduced in https://github.com/backdrop-contrib/rules/issues/140 and further separates test functions and files from regular module functions and files.