### PR TITLE
Issue #162: Include Entity Token module in GHA automated tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -36,6 +36,12 @@ jobs:
           repository: backdrop-contrib/entity_ui
           path: modules/entity_ui
 
+      - name: Checkout Entity Tokens
+        uses: actions/checkout@v2
+        with:
+          repository: backdrop-contrib/entity_token
+          path: modules/entity_token
+
       - name: Checkout module
         uses: actions/checkout@v2
         with:

--- a/rules_admin/tests/rules_admin_minimal_profile.test
+++ b/rules_admin/tests/rules_admin_minimal_profile.test
@@ -24,7 +24,7 @@ class RulesAdminMinimalProfileTestCase extends BackdropWebTestCase {
    * Overrides BackdropWebTestCase::setUp().
    */
   protected function setUp() {
-    parent::setUp('entity_token', 'rules', 'rules_admin');
+    parent::setUp('rules', 'rules_admin');
     RulesLog::logger()->clear();
     variable_set('rules_debug_log', TRUE);
   }

--- a/rules_admin/tests/rules_admin_minimal_profile.test
+++ b/rules_admin/tests/rules_admin_minimal_profile.test
@@ -24,7 +24,7 @@ class RulesAdminMinimalProfileTestCase extends BackdropWebTestCase {
    * Overrides BackdropWebTestCase::setUp().
    */
   protected function setUp() {
-    parent::setUp('rules', 'rules_admin');
+    parent::setUp('entity_token', 'rules', 'rules_admin');
     RulesLog::logger()->clear();
     variable_set('rules_debug_log', TRUE);
   }


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/rules/issues/162.

This is a test to see if we need to explicitly enable entity_token module. [Edit: yes, we do, in the GHA setup.]