### PR TITLE
Issue 138: Enable Backdrop-only modules required for Rules.

### DIFF
--- a/rules.install
+++ b/rules.install
@@ -5,6 +5,45 @@
  */
 
 /**
+ * Implements hook_requirements().
+ */
+function rules_requirements($phase) {
+  $requirements = array();
+  if ($phase == 'update') {
+    // Required Backdrop modules that were not part of D7 installation.
+    $backdrop_modules = array(
+      'entity_ui' => 'Entity UI',
+      'entity_plus' => 'Entity Plus',
+    );
+    foreach ($backdrop_modules as $module => $module_name) {
+      if (module_exists($module)) {
+        // The module is already installed and enabled, nothing more to do.
+        continue;
+      }
+      $module_files = backdrop_system_listing('/' . $module . '\.module$/', 'modules', 'name', 0);;
+      if (empty($module_files)) {
+        // Module doesn't exist in the code base, so halt the upgrade process.
+        $requirements[] = array(
+          'title' => $module_name,
+          'description' => t('Please add the Backdrop module @module_name to your installation; it is required for the Rules module.', array('@module_name' => $module_name)),
+          'severity' => REQUIREMENT_ERROR,
+        );
+      }
+      else {
+        // Module exists in the code base, but isn't enabled so enable it.
+        module_enable(array($module));
+        $requirements[] = array(
+          'title' => $module_name,
+          'description' => t('The Backdrop module @module_name has been enabled; it is required for the Rules module.', array('@module_name' => $module_name)),
+          'severity' => REQUIREMENT_OK,
+        );
+      }
+    }
+  }
+  return $requirements;
+}
+
+/**
  * Implements hook_enable().
  */
 function rules_enable() {

--- a/rules.install
+++ b/rules.install
@@ -20,7 +20,7 @@ function rules_requirements($phase) {
         // The module is already installed and enabled, nothing more to do.
         continue;
       }
-      $module_files = backdrop_system_listing('/' . $module . '\.module$/', 'modules', 'name', 0);;
+      $module_files = backdrop_system_listing('/^' . $module . '\.module$/', 'modules', 'name', 0);
       if (empty($module_files)) {
         // Module doesn't exist in the code base, so halt the upgrade process.
         $requirements[] = array(

--- a/rules.module
+++ b/rules.module
@@ -1482,6 +1482,13 @@ function rules_element_info() {
  * Implements hook_modules_enabled().
  */
 function rules_modules_enabled($modules) {
+  if (!module_exists('entity_plus')) {
+    // Ordinarily, Entity Plus would be enabled before Rules, but if it's not
+    // (which can happen during an upgrade from D7 when we enable Entity Plus as
+    // part of hook_requirements()), then its functions are not accessible to
+    // Rules, so we'll have to bail.
+    return;
+  }
   _entity_plus_defaults_rebuild('rules_config');
   // Re-enable Rules configurations that are dirty, because they require one of
   // the enabled the modules.


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/rules/issues/138.