### PR TITLE
Issue #159. Deal with drupal-only actions

### DIFF
--- a/modules/system.eval.inc
+++ b/modules/system.eval.inc
@@ -15,6 +15,17 @@ function rules_action_backdrop_message($message, $status, $repeat) {
   backdrop_set_message(filter_xss_admin($message), $status, $repeat);
 }
 
+/** 
+ * Action: Show a backdrop message (drupal namespace).
+ * 
+ * @deprecated
+ */
+function rules_action_drupal_message($message, $status, $repeat) {
+  watchdog('rules', 'The action drupal_message is deprecated. This action is now named <em>backdrop_message</em>.', array(), WATCHDOG_DEPRECATED);
+  rules_log('The action drupal_message is deprecated. This action is now named <em>backdrop_message</em>.', array(), RulesLog::WARN);
+  rules_action_backdrop_message($message, $status, $repeat);
+}
+
 /**
  * Action: Write a watchdog db log message.
  */
@@ -27,6 +38,17 @@ function rules_action_backdrop_watchdog($type, $message, $severity, $link_text, 
     $link = NULL;
   }
   watchdog($type, $message, array(), $severity, $link);
+}
+
+/** 
+ * Action: Write a watchdog db log message (drupal namespace).
+ * 
+ * @deprecated
+ */
+function rules_action_drupal_watchdog($type, $message, $severity, $link_text, $link_path) {
+  watchdog('rules', 'The action drupal_watchdog is deprecated. This action is now named <em>backdrop_watchdog</em>.', array(), WATCHDOG_DEPRECATED);
+  rules_log('The action drupal_watchdog is deprecated. This action is now named <em>backdrop_watchdog</em>.', array(), RulesLog::WARN);
+  rules_action_backdrop_watchdog($type, $message, $severity, $link_text, $link_path);
 }
 
 /**

--- a/modules/system.rules.inc
+++ b/modules/system.rules.inc
@@ -97,7 +97,7 @@ function _rules_system_watchdog_log_entry_info() {
  * Implements hook_rules_action_info() on behalf of the system module.
  */
 function rules_system_action_info() {
-  return array(
+  $return = array(
     'backdrop_message' => array(
       'label' => t('Show a message on the site'),
       'group' => t('System'),
@@ -304,6 +304,18 @@ function rules_system_action_info() {
       'access callback' => 'rules_system_integration_access',
     ),
   );
+
+  $return['drupal_message'] = $return['backdrop_message'];
+  $return['drupal_message']['label'] = t('Show a message on the site. DEPRECATED.');
+  $return['drupal_message']['base'] = 'rules_action_drupal_message';
+  $return['drupal_message']['hidden'] = TRUE; // @todo To be implemented
+  
+  $return['drupal_watchdog'] = $return['backdrop_watchdog'];
+  $return['drupal_watchdog']['label'] = t('Logs a message to the system dblog. DEPRECATED.');
+  $return['drupal_watchdog']['base'] = 'rules_action_drupal_watchdog';
+  $return['drupal_watchdog']['hidden'] = TRUE; // @todo To be implemented
+
+  return $return;
 }
 
 /**

--- a/ui/ui.core.inc
+++ b/ui/ui.core.inc
@@ -1318,10 +1318,14 @@ class RulesUICategory {
         continue;
       }
       if ($group = RulesUICategory::getItemGroup($info)) {
-        $sorted_data[backdrop_ucfirst($group)][$name] = backdrop_ucfirst($info['label']);
+        if (empty($info['hidden'])) {
+          $sorted_data[backdrop_ucfirst($group)][$name] = backdrop_ucfirst($info['label']);
+        }
       }
       else {
-        $ungrouped[$name] = backdrop_ucfirst($info['label']);
+        if (empty($info['hidden'])) {
+          $ungrouped[$name] = backdrop_ucfirst($info['label']);
+        }
       }
     }
     asort($ungrouped);


### PR DESCRIPTION
Fixes #159. WIP

This is a work in progress. So far, this deals with drupal_message and drupal_watchdog. 

~~TODO: find a way to hide these two actions from the Add new action select box.~~