### PR TITLE
Issue #182. Provide bundle and label methods

### DIFF
--- a/includes/rules.core.inc
+++ b/includes/rules.core.inc
@@ -18,6 +18,10 @@ require_once dirname(__FILE__) . '/faces.inc';
  */
 class RulesConfigEntity extends Entity {
 
+  public function __construct(array $values = array())
+  {
+    parent::__construct($values);
+  }
   /**
    * Implements EntityInterface::id().
    */
@@ -35,12 +39,16 @@ class RulesConfigEntity extends Entity {
   /**
    * Implements EntityInterface::bundle().
    */
-  public function bundle() {}
+  public function bundle() {
+    return 'rules_config';
+  }
 
   /**
    * Implements EntityInterface::label().
    */
-  public function label() {}
+  public function label() {
+    return $this->label;
+  }
 
   /**
    * Implements EntityInterface::uri().

--- a/includes/rules.core.inc
+++ b/includes/rules.core.inc
@@ -18,10 +18,6 @@ require_once dirname(__FILE__) . '/faces.inc';
  */
 class RulesConfigEntity extends Entity {
 
-  public function __construct(array $values = array())
-  {
-    parent::__construct($values);
-  }
   /**
    * Implements EntityInterface::id().
    */

--- a/includes/rules.core.inc
+++ b/includes/rules.core.inc
@@ -37,13 +37,6 @@ class RulesConfigEntity extends Entity {
   }
 
   /**
-   * Implements EntityInterface::bundle().
-   */
-  public function bundle() {
-    return 'rules_config';
-  }
-
-  /**
    * Implements EntityInterface::label().
    */
   public function label() {


### PR DESCRIPTION
Fixes #182.

However, these fixes will have no effect, as the entity `rules_config` it's a wrapper for other classes provided by Rules that don't extend `Entity`. In those classes, the method `label` already exists, but the method `bundle` does not. 

In other words,  they class `RulesConfigEntity` doesn't seem to be use at all to hold entities.

See comment: https://github.com/backdrop-contrib/rules/issues/182#issuecomment-1140529377