### PR TITLE
Issue #186: Stop using deprecated taxonomy_vocabulary_get_names()

### DIFF
--- a/ui/ui.data.inc
+++ b/ui/ui.data.inc
@@ -672,7 +672,7 @@ class RulesDataUITaxonomyVocabulary extends RulesDataUIEntity implements RulesDa
    */
   public static function optionsList(RulesPlugin $element, $name) {
     $options = array();
-    foreach (taxonomy_vocabulary_get_names() as $machine_name => $vocab) {
+    foreach (taxonomy_vocabulary_load_multiple(FALSE) as $machine_name => $vocab) {
       $options[$machine_name] = $vocab->name;
     }
     return $options;


### PR DESCRIPTION
Fixes #186