### PR TITLE
Issue #222: Ensure events and actions have groups (D7 port).

### DIFF
--- a/tests/rules_test/rules_test.rules.inc
+++ b/tests/rules_test/rules_test.rules.inc
@@ -11,6 +11,7 @@ function rules_test_rules_event_info() {
   return array(
     'rules_test_event' => array(
       'label' => t('Test event'),
+      'group' => t('Rules test'),
       'class' => 'RulesTestEventHandler',
     ),
   );
@@ -129,6 +130,7 @@ function rules_test_rules_action_info() {
       'callbacks' => array(
         'help' => 'rules_test_custom_help',
       ),
+      'group' => t('Rules test'),
       'base' => 'rules_action_node_publish',
     ),
     'rules_node_publish_action_save' => array(
@@ -140,6 +142,7 @@ function rules_test_rules_action_info() {
           'save' => TRUE,
         ),
       ),
+      'group' => t('Rules test'),
       'base' => 'rules_action_node_publish',
     ),
     'rules_node_make_sticky_action' => array(
@@ -151,6 +154,7 @@ function rules_test_rules_action_info() {
           'save' => TRUE,
         ),
       ),
+      'group' => t('Rules test'),
       'base' => 'rules_action_node_make_sticky',
     ),
     // The same action again requiring a 'page' node.
@@ -164,6 +168,7 @@ function rules_test_rules_action_info() {
           'bundles' => array('page'),
         ),
       ),
+      'group' => t('Rules test'),
       'base' => 'rules_action_node_make_sticky',
     ),
     'rules_action_test_reference' => array(
@@ -171,6 +176,7 @@ function rules_test_rules_action_info() {
       'parameter' => array(
          // For references working right, we need a data type with a wrapper.
         'arg' => array('type' => 'test'),
+        'group' => t('Rules test'),
       ),
     ),
     'rules_action_load_node' => array(

--- a/tests/rules_test/rules_test.rules.inc
+++ b/tests/rules_test/rules_test.rules.inc
@@ -176,8 +176,8 @@ function rules_test_rules_action_info() {
       'parameter' => array(
          // For references working right, we need a data type with a wrapper.
         'arg' => array('type' => 'test'),
-        'group' => t('Rules test'),
       ),
+      'group' => t('Rules test'),
     ),
     'rules_action_load_node' => array(
       'label' => t('Fetch content by id'),


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/rules/issues/222.