### PR TITLE
Issue #253. Check for null in elementName to avoid warnings in PHP 8.5

### DIFF
--- a/includes/rules.core.inc
+++ b/includes/rules.core.inc
@@ -1564,7 +1564,7 @@ abstract class RulesAbstractPlugin extends RulesPlugin {
 
   protected function setUp() {
     parent::setUp();
-    if (isset($this->cache[$this->itemName . '_info'][$this->elementName])) {
+    if (!is_null($this->elementName) && isset($this->cache[$this->itemName . '_info'][$this->elementName])) {
       $this->info = $this->cache[$this->itemName . '_info'][$this->elementName];
       // Remember that the info has been correctly setup.
       // @see self::forceSetup()


### PR DESCRIPTION
Fixes #253